### PR TITLE
ci: Fix Workflow for release-please

### DIFF
--- a/.github/workflows/build-prod-release.yml
+++ b/.github/workflows/build-prod-release.yml
@@ -21,7 +21,6 @@ jobs:
         id: release_please
         uses: fortify/3rdparty-actions/actions/googleapis/release-please-action/v5@main
         with:
-          skip-github-release: true
           target-branch: ${{ github.ref_name }}
           release-type: simple
           

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,7 +1,0 @@
-{
-  "changelog-sections": [
-    { "type": "feat", "section": "Features", "hidden": false },
-    { "type": "fix",  "section": "Bug Fixes", "hidden": false },
-    { "type": "api",  "section": "API changes", "hidden": false }
-  ]
-}


### PR DESCRIPTION
Remove `release-please-config.json`: not needed for non-API projects.

Remove `skip-github-release: true`. this workflow invokes release-please once for both PR generation and GitHub release creation.